### PR TITLE
DL-1728 Pad 7 digit CRNs before submission

### DIFF
--- a/test/models/EtmpModelHelperSpec.scala
+++ b/test/models/EtmpModelHelperSpec.scala
@@ -970,4 +970,112 @@ class EtmpModelHelperSpec extends UnitSpec with AwrsTestJson {
     }
   }
 
+  "identificationCorpNumbersWithCRNType" should {
+    "not pad a CRN and produce json" when {
+      "the CRN is 8 digits" in {
+        val identification: CorpNumbersWithCRNType = BusinessDirector(
+          personOrCompany = "yes",
+          directorsAndCompanySecretaries = "foo",
+          doYouHaveCRN = Some("yes"),
+          companyRegNumber = Some("12345678")
+        )
+
+        val json = TestEtmpModelHelper.identificationCorpNumbersWithCRNType(identification)
+        (json \ "companyRegNumber").get.as[String] shouldBe "12345678"
+      }
+
+      "the CRN is a scottish company" in {
+        val identification: CorpNumbersWithCRNType = BusinessDirector(
+          personOrCompany = "yes",
+          directorsAndCompanySecretaries = "foo",
+          doYouHaveCRN = Some("yes"),
+          companyRegNumber = Some("SC999999")
+        )
+
+        val json = TestEtmpModelHelper.identificationCorpNumbersWithCRNType(identification)
+        (json \ "companyRegNumber").get.as[String] shouldBe "SC999999"
+      }
+    }
+
+    "pad a CRN and produce json" when {
+      "the CRN is 7 digits" in {
+        val identification: CorpNumbersWithCRNType = BusinessDirector(
+          personOrCompany = "yes",
+          directorsAndCompanySecretaries = "foo",
+          doYouHaveCRN = Some("yes"),
+          companyRegNumber = Some("1234567")
+        )
+
+        val json = TestEtmpModelHelper.identificationCorpNumbersWithCRNType(identification)
+        (json \ "companyRegNumber").get.as[String] shouldBe "01234567"
+      }
+    }
+  }
+
+  "identificationIncorporationDetails" should {
+    "not pad a CRN and produce json" when {
+      "the CRN is 8 digits" in {
+        val identification: IncorporationDetails = GroupMember(
+          companyNames = CompanyNames(None, None, None),
+          isBusinessIncorporated = Some("Yes"),
+          companyRegDetails = Some(CompanyRegDetails(
+            companyRegistrationNumber = "12345678",
+            dateOfIncorporation = "20/05/1970"
+          )),
+          address = None,
+          doYouHaveVRN = None,
+          vrn = None,
+          doYouHaveUTR = None,
+          utr = None,
+          addAnotherGrpMember = None
+        )
+
+        val json = TestEtmpModelHelper.identificationIncorporationDetails(identification)
+        (json \ "companyRegistrationNumber").get.as[String] shouldBe "12345678"
+      }
+
+      "the CRN is a scottish company" in {
+        val identification: IncorporationDetails = GroupMember(
+          companyNames = CompanyNames(None, None, None),
+          isBusinessIncorporated = Some("Yes"),
+          companyRegDetails = Some(CompanyRegDetails(
+            companyRegistrationNumber = "SC999999",
+            dateOfIncorporation = "20/05/1970"
+          )),
+          address = None,
+          doYouHaveVRN = None,
+          vrn = None,
+          doYouHaveUTR = None,
+          utr = None,
+          addAnotherGrpMember = None
+        )
+
+        val json = TestEtmpModelHelper.identificationIncorporationDetails(identification)
+        (json \ "companyRegistrationNumber").get.as[String] shouldBe "SC999999"
+      }
+    }
+
+    "pad a CRN and produce json" when {
+      "the CRN is 7 digits" in {
+        val identification: IncorporationDetails = GroupMember(
+          companyNames = CompanyNames(None, None, None),
+          isBusinessIncorporated = Some("Yes"),
+          companyRegDetails = Some(CompanyRegDetails(
+            companyRegistrationNumber = "1234567",
+            dateOfIncorporation = "20/05/1970"
+          )),
+          address = None,
+          doYouHaveVRN = None,
+          vrn = None,
+          doYouHaveUTR = None,
+          utr = None,
+          addAnotherGrpMember = None
+        )
+
+        val json = TestEtmpModelHelper.identificationIncorporationDetails(identification)
+        (json \ "companyRegistrationNumber").get.as[String] shouldBe "01234567"
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
# DL-1728 Pad 7 digit CRNs before submission

**Bug fix**

* This story is to fix submissions in which users are sending down CRNs with 7 digits. These are not actuallly valid on ETMP, but at the same time, the user needs to be able to enter CRNs with 7 digits as they receive a physical letter showing 7 digits, on occasion. For this reason, we need to pad them just before submission to ETMP.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
