### PR TITLE
DL-2783 Amend self-heal check return body

### DIFF
--- a/app/controllers/EtmpCheckController.scala
+++ b/app/controllers/EtmpCheckController.scala
@@ -42,7 +42,9 @@ class EtmpCheckController @Inject()(cc: ControllerComponents,
         val businessCustomerDetails = regime.businessCustomerDetails
 
         etmpRegimeService.checkETMPApi(safeId, businessCustomerDetails, businessRegistrationDetails).map {
-          case Some(_) => Ok
+          case Some(etmpRegistrationDetails) =>
+            val responseJson = Json.obj("regimeRefNumber" -> etmpRegistrationDetails.regimeRefNumber)
+            Ok(responseJson)
           case _ =>
             Logger.warn("[EtmpCheckController][checkEtmp] Could not retrieve/upsert for checkEtmp")
             NoContent

--- a/app/services/EtmpRegimeService.scala
+++ b/app/services/EtmpRegimeService.scala
@@ -143,9 +143,9 @@ class EtmpRegimeService @Inject()(etmpConnector: EtmpConnector,
   private[services] def matchOrg(bcd: BusinessCustomerDetails, erd: EtmpRegistrationDetails): Boolean = {
     Map(
       "businessName" -> erd.organisationName.map(_.toUpperCase).contains(bcd.businessName.toUpperCase),
-      "sapNumber" -> (bcd.sapNumber.toUpperCase == erd.sapNumber.toUpperCase),
-      "safeId" -> (bcd.safeId.toUpperCase == erd.safeId.toUpperCase),
-      "agentRef" -> compareOptionalStrings(bcd.agentReferenceNumber, erd.agentReferenceNumber)
+      "sapNumber"    -> (bcd.sapNumber.toUpperCase == erd.sapNumber.toUpperCase),
+      "safeId"       -> (bcd.safeId.toUpperCase == erd.safeId.toUpperCase),
+      "agentRef"     -> compareOptionalStrings(bcd.agentReferenceNumber, erd.agentReferenceNumber)
     ).partition{case (_, v) => v} match {
       case (_, failures) if failures.isEmpty => true
       case (_, failures) =>
@@ -155,8 +155,8 @@ class EtmpRegimeService @Inject()(etmpConnector: EtmpConnector,
   }
 
   private[services] def getEtmpRegistrationDetails(affinityGroup: Option[AffinityGroup],
-                                         bcd: BusinessCustomerDetails,
-                                         erd: EtmpRegistrationDetails): Option[EtmpRegistrationDetails] = {
+                                                   bcd: BusinessCustomerDetails,
+                                                   erd: EtmpRegistrationDetails): Option[EtmpRegistrationDetails] = {
     affinityGroup match {
       case Some(AffinityGroup.Individual)   if matchIndividual(bcd, erd) => Some(erd)
       case Some(AffinityGroup.Organisation) if matchOrg(bcd, erd)        => Some(erd)

--- a/test/controllers/EtmpCheckControllerTest.scala
+++ b/test/controllers/EtmpCheckControllerTest.scala
@@ -53,6 +53,7 @@ class EtmpCheckControllerTest extends BaseSpec with MockitoSugar {
 
         val result = TestEtmpCheckController.checkEtmp().apply(FakeRequest().withJsonBody(Json.parse(etmpCheckOrganisationString)))
         status(result) shouldBe OK
+        contentAsString(result) shouldBe Json.obj("regimeRefNumber" -> "regRef").toString()
       }
 
       "there is a regime model and there is ETMP registration details for an individual" in {
@@ -61,7 +62,7 @@ class EtmpCheckControllerTest extends BaseSpec with MockitoSugar {
           "sapNumber",
           "safeId",
           None,
-          "regRef",
+          "regRefInd",
           None
         )
 
@@ -70,6 +71,7 @@ class EtmpCheckControllerTest extends BaseSpec with MockitoSugar {
 
         val result = TestEtmpCheckController.checkEtmp().apply(FakeRequest().withJsonBody(Json.parse(etmpCheckIndividualString)))
         status(result) shouldBe OK
+        contentAsString(result) shouldBe Json.obj("regimeRefNumber" -> "regRefInd").toString()
       }
     }
 


### PR DESCRIPTION
# DL-2783 Amend self-heal check return body

**New feature**

* Self-check end point now returns regime ref number from the API ETMP endpoint

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
