### PR TITLE
DL-4363: Show error to user when enrolment call fails

### DIFF
--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -43,20 +43,17 @@ class SubscriptionService @Inject()(metrics: AwrsMetrics,
     val timer = metrics.startTimer(ApiType.API4Subscribe)
     for {
       submitResponse <- etmpConnector.subscribe(data, safeId)
-      ggResponse <- addKnownFacts(submitResponse, safeId, utr, businessType, postcode)
+      enrolmentResponse <- addKnownFacts(submitResponse, safeId, utr, businessType, postcode)
     } yield {
-      ggResponse.status match {
-        case OK =>
+      (submitResponse.status, enrolmentResponse.status) match {
+        case (OK, NO_CONTENT) =>
           timer.stop()
           metrics.incrementSuccessCounter(ApiType.API4AddKnownFacts)
           submitResponse
         case _ =>
           timer.stop()
           metrics.incrementFailedCounter(ApiType.API4AddKnownFacts)
-          // Code changed to always return the etmp response even if there is a GG failure.
-          // The GG failure will need to be sorted out manually and there is nothing the user can do at the time.
-          // The manual process will take place after the GG failure is picked up in Splunk.
-          submitResponse
+          enrolmentResponse
       }
     }
   }
@@ -77,7 +74,7 @@ class SubscriptionService @Inject()(metrics: AwrsMetrics,
         val enrolmentKey = s"$AWRS_SERVICE_NAME~AWRSRefNumber~$awrsRegistrationNumber"
         val enrolmentVerifiers = createVerifiers(safeId, utr, businessType, postcode)
         enrolmentStoreConnector.upsertEnrolment(enrolmentKey, enrolmentVerifiers)
-      case _ => Future.successful(response)
+      case _ => Future(response)
     }
 
   private def createVerifiers(safeId: String, utr: Option[String], businessType: String, postcode: String) = {

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val silencerVersion = "1.7.1"
 val appName: String = "awrs"
 
 lazy val appDependencies : Seq[ModuleID] = AppDependencies()
-lazy val plugins : Seq[Plugins] = Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory)
+lazy val plugins : Seq[Plugins] = Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin)
 lazy val playSettings : Seq[Setting[_]] = Seq.empty
 
 lazy val scoverageSettings = {
@@ -28,7 +28,7 @@ lazy val microservice = Project(appName, file("."))
   .settings(publishingSettings: _*)
   .settings(defaultSettings(): _*)
   .settings(
-    scalaVersion := "2.12.11",
+    scalaVersion := "2.12.12",
     libraryDependencies ++= appDependencies,
     parallelExecution in Test := false,
     retrieveManaged := true,

--- a/it/uk/gov/hmrc/helpers/controllers/EtmpCheckControllerSpec.scala
+++ b/it/uk/gov/hmrc/helpers/controllers/EtmpCheckControllerSpec.scala
@@ -17,309 +17,104 @@
 package uk.gov.hmrc.helpers.controllers
 
 import controllers.routes
-import models.{Pending, Rejected}
+import models.{Approved, Rejected}
 import org.scalatest.MustMatchers
-import play.api.http.Status.{BAD_REQUEST, NO_CONTENT, OK}
-import play.api.libs.json.{JsValue, Json}
+import play.api.http.Status.{NO_CONTENT, OK, NOT_FOUND}
 import play.api.libs.ws.WSResponse
+import uk.gov.hmrc.helpers.utils.Stubs
 import uk.gov.hmrc.helpers.{AuthHelpers, IntegrationSpec}
 import utils.{AWRSFeatureSwitches, FeatureSwitch}
 
-class EtmpCheckControllerSpec extends IntegrationSpec with AuthHelpers with MustMatchers {
+class EtmpCheckControllerSpec extends IntegrationSpec with AuthHelpers with MustMatchers with Stubs {
 
-  val baseURI = "/alcohol-wholesaler-register"
-  val subscriptionURI = "/subscription/"
-  val regimeURI = "/registration/details"
-  val safeId: String = "XE0001234567890"
-  val AWRS_SERVICE_NAME = "HMRC-AWRS-ORG"
-  val enrolmentKey = s"$AWRS_SERVICE_NAME~AWRSRefNumber~XAAW00000123456"
+  val controllerUrl: String = routes.EtmpCheckController.checkEtmp().url
 
-  val jsonPostData = Json.parse("""{
-                                  |  "businessCustomerDetails": {
-                                  |    "businessName": "sdfsdf",
-                                  |    "businessType": "Corporate Body",
-                                  |    "businessAddress": {
-                                  |      "line_1": "1 Example Street",
-                                  |      "line_2": "Exampe View",
-                                  |      "line_3": "Exampe Town",
-                                  |      "line_4": "Exampeshire",
-                                  |      "postcode": "AA1 1AA",
-                                  |      "country": "GB"
-                                  |    },
-                                  |    "sapNumber": "1234567890",
-                                  |    "safeId": "XE0001234567890",
-                                  |    "isAGroup": false,
-                                  |    "agentReferenceNumber": "JARN1234567"
-                                  |  },
-                                  |  "businessRegistrationDetails": {
-                                  |    "legalEntity": "LTD",
-                                  |    "isBusinessIncorporated": "Yes",
-                                  |    "companyRegDetails": {
-                                  |      "companyRegistrationNumber": "55555555",
-                                  |      "dateOfIncorporation": "01/01/2015"
-                                  |    },
-                                  |    "doYouHaveVRN": "Yes",
-                                  |    "vrn": "000000000",
-                                  |    "doYouHaveUTR": "Yes",
-                                  |    "utr": "utr"
-                                  |  },
-                                  |  "legalEntity": "LTD"
-                                  |}
-                                  |""".stripMargin)
+  "checkEtmp()" should {
 
-  "return NO CONTENT" when {
+    "return 200 for a successful self heal" when {
 
-    "AWRS feature flag is false" in {
+      "EMAC feature flag is true" when {
 
-      val successResponse: JsValue = Json.parse(
-        s"""{"processingDate":"2015-12-17T09:30:47Z","etmpFormBundleNumber":"123456789012345","awrsRegistrationNumber": "DummyRef"}"""
-      )
+        "there is a business partner and regime in ETMP" when {
 
-      stubbedPost(s"""$baseURI$subscriptionURI$safeId""", BAD_REQUEST, successResponse.toString)
-      stubbedPut(s"/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey", OK)
+          "the status of the AWRS subscription is not a NonSelfHealStatus" when {
 
-      val controllerUrl = routes.EtmpCheckController.checkEtmp().url
+            "the business details provided match the details held on the business partner" when {
 
-      val resp: WSResponse = await(client(controllerUrl).post(jsonPostData))
-      resp.status mustBe 204
+              "the enrolment has been upserted successfully" when {
+
+                "the user is an organisation" in {
+
+                  FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
+                  stubAuditPosts
+                  stubEtmpRegistrationResponse(OK, etmpRegistrationResultOrg)
+                  stubAwrsSubscriptionResponse(OK, Some(subscriptionSuccessResponse))
+                  stubShowAndRedirectExternalCalls("Organisation")
+                  stubGetSubscriptionStatus(OK, Some(Approved.name))
+                  stubUpsertAwrsEnrolment(NO_CONTENT)
+
+                  val resp: WSResponse = await(client(controllerUrl).post(checkEtmpPostDataOrg))
+                  resp.status mustBe 200
+                }
+
+                "the user is an individual" in {
+
+                  FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
+                  stubAuditPosts
+                  stubEtmpRegistrationResponse(OK, etmpRegistrationResultInd)
+                  stubAwrsSubscriptionResponse(OK, Some(subscriptionSuccessResponse))
+                  stubShowAndRedirectExternalCalls("Individual")
+                  stubGetSubscriptionStatus(OK, Some(Approved.name))
+                  stubUpsertAwrsEnrolment(NO_CONTENT)
+
+                  val resp: WSResponse = await(client(controllerUrl).post(checkEtmpPostDataInd))
+                  resp.status mustBe 200
+                }
+              }
+            }
+          }
+        }
+      }
     }
 
-    "AWRS feature flag is true, but the status is rejected" in {
+    "return 204" when {
 
-      val jsResultString =
-        """
-          |{
-          |  "sapNumber": "1234567890",
-          |  "safeId": "XE0001234567890",
-          |  "agentReferenceNumber": "JARN1234567",
-          |  "regimeIdentifiers": [
-          |    {
-          |      "regimeName": "AWRS",
-          |      "regimeRefNumber": "XAAW00000123456"
-          |    }
-          |  ],
-          |  "nonUKIdentification": {
-          |    "idNumber": "123456",
-          |    "issuingInstitution": "France Institution",
-          |    "issuingCountryCode": "FR"
-          |  },
-          |  "isEditable": true,
-          |  "isAnAgent": false,
-          |  "isAnIndividual": true,
-          |  "addressDetails": {
-          |    "addressLine1": "100 SomeStreet",
-          |    "addressLine2": "Wokingham",
-          |    "addressLine3": "Surrey",
-          |    "addressLine4": "London",
-          |    "postalCode": "DH14EJ",
-          |    "countryCode": "GB"
-          |  },
-          |  "contactDetails": {
-          |    "regimeName": "AWRS",
-          |    "phoneNumber": "01332752856",
-          |    "mobileNumber": "07782565326",
-          |    "faxNumber": "01332754256",
-          |    "emailAddress": "stephen@manncorpone.co.uk"
-          |  }
-          |}
-        """.stripMargin
+      "EMAC feature flag is false" in {
+        FeatureSwitch.disable(AWRSFeatureSwitches.regimeCheck())
+        stubAuditPosts
 
-      val successResponse: JsValue = Json.parse(
-        s"""{"processingDate":"2015-12-17T09:30:47Z","etmpFormBundleNumber":"123456789012345","awrsRegistrationNumber": "XAAW00000123456"}"""
-      )
+        val resp: WSResponse = await(client(controllerUrl).post(checkEtmpPostDataInd))
+        resp.status mustBe 204
+      }
 
-      FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
+      "EMAC feature flag is true" when {
 
-      val statusresp = Json.obj(
-        "processingDate" -> "20/01/2010",
-        "formBundleStatus" -> Rejected.name,
-        "groupBusinessPartner" -> false
-      )
+        "there is a business partner and regime in ETMP" when {
 
-      stubbedGet(s"""$regimeURI""", OK, jsResultString)
-      stubbedPost(s"""$baseURI$subscriptionURI$safeId""", OK, successResponse.toString)
-      stubbedGet(s"""$baseURI${subscriptionURI}XAAW00000123456/status""", OK, statusresp.toString())
-      stubbedPost(s"/auth/authorise", OK,
-        """
-          |{
-          | "affinityGroup": "Individual"
-          |}
-        """.stripMargin)
-      stubbedPut(s"/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey", NO_CONTENT)
+          "the status of the AWRS subscription is a NonSelfHealStatus" in {
 
-      val controllerUrl = routes.EtmpCheckController.checkEtmp().url
+            FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
+            stubAuditPosts
+            stubEtmpRegistrationResponse(OK, etmpRegistrationResultInd)
+            stubShowAndRedirectExternalCalls("Individual")
+            stubGetSubscriptionStatus(OK, Some(Rejected.name))
 
-      val resp: WSResponse = await(client(controllerUrl).post(jsonPostData))
-      resp.status mustBe 204
+            val resp: WSResponse = await(client(controllerUrl).post(checkEtmpPostDataInd))
+            resp.status mustBe 204
+
+          }
+        }
+
+        "there is no business partner and regime in ETMP" in {
+
+          FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
+          stubAuditPosts
+          stubEtmpRegistrationResponse(NOT_FOUND, "")
+
+          val resp: WSResponse = await(client(controllerUrl).post(checkEtmpPostDataOrg))
+          resp.status mustBe 204
+        }
+      }
     }
   }
-
-  "AWRS feature flag is true" in {
-
-    val jsResultString =
-      """
-        |{"regimeIdentifiers": [
-        |{
-        |  "regimeName": "String",
-        |  "regimeRefNumber": "AWRS"
-        |}
-        |]}
-      """.stripMargin
-
-    val successResponse: JsValue = Json.parse(
-      s"""{"processingDate":"2015-12-17T09:30:47Z","etmpFormBundleNumber":"123456789012345","awrsRegistrationNumber": "DummyRef"}"""
-    )
-
-    FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
-
-    stubbedGet(s"""$regimeURI""", OK, jsResultString)
-    stubbedPost(s"""$baseURI$subscriptionURI$safeId""", BAD_REQUEST, successResponse.toString)
-    stubbedPut(s"/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey", OK)
-
-    val controllerUrl = routes.EtmpCheckController.checkEtmp().url
-
-    val resp: WSResponse = await(client(controllerUrl).post(jsonPostData))
-    resp.status mustBe 204
-  }
-
-  "return 200" when {
-
-    "AWRS feature flag is true" in {
-
-      val jsResultString =
-        """
-          |{
-          |  "sapNumber": "1234567890",
-          |  "safeId": "XE0001234567890",
-          |  "agentReferenceNumber": "JARN1234567",
-          |  "regimeIdentifiers": [
-          |    {
-          |      "regimeName": "AWRS",
-          |      "regimeRefNumber": "XAAW00000123456"
-          |    }
-          |  ],
-          |  "nonUKIdentification": {
-          |    "idNumber": "123456",
-          |    "issuingInstitution": "France Institution",
-          |    "issuingCountryCode": "FR"
-          |  },
-          |  "isEditable": true,
-          |  "isAnAgent": false,
-          |  "isAnIndividual": false,
-          |  "organisation": {
-          |    "organisationName": "sdfsdf",
-          |    "isAGroup": false,
-          |    "organisationType": "Corporate body"
-          |  },
-          |  "addressDetails": {
-          |    "addressLine1": "100 SomeStreet",
-          |    "addressLine2": "Wokingham",
-          |    "addressLine3": "Surrey",
-          |    "addressLine4": "London",
-          |    "postalCode": "DH14EJ",
-          |    "countryCode": "GB"
-          |  },
-          |  "contactDetails": {
-          |    "regimeName": "AWRS",
-          |    "phoneNumber": "01332752856",
-          |    "mobileNumber": "07782565326",
-          |    "faxNumber": "01332754256",
-          |    "emailAddress": "stephen@manncorpone.co.uk"
-          |  }
-          |}
-        """.stripMargin
-
-      val successResponse: JsValue = Json.parse(
-        s"""{"processingDate":"2015-12-17T09:30:47Z","etmpFormBundleNumber":"123456789012345","awrsRegistrationNumber": "XAAW00000123456"}"""
-      )
-
-      FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
-
-      stubbedGet(s"""$regimeURI""", OK, jsResultString)
-      stubbedPost(s"""$baseURI$subscriptionURI$safeId""", OK, successResponse.toString)
-      stubbedPost(s"/auth/authorise", OK,
-        """
-          |{
-          | "affinityGroup": "Organisation"
-          |}
-        """.stripMargin)
-      stubbedPut(s"/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey", NO_CONTENT)
-
-      val controllerUrl = routes.EtmpCheckController.checkEtmp().url
-
-      val resp: WSResponse = await(client(controllerUrl).post(jsonPostData))
-      resp.status mustBe 200
-    }
-
-    "AWRS feature flag is true for an individual" in {
-
-      val jsResultString =
-        """
-          |{
-          |  "sapNumber": "1234567890",
-          |  "safeId": "XE0001234567890",
-          |  "agentReferenceNumber": "JARN1234567",
-          |  "regimeIdentifiers": [
-          |    {
-          |      "regimeName": "AWRS",
-          |      "regimeRefNumber": "XAAW00000123456"
-          |    }
-          |  ],
-          |  "nonUKIdentification": {
-          |    "idNumber": "123456",
-          |    "issuingInstitution": "France Institution",
-          |    "issuingCountryCode": "FR"
-          |  },
-          |  "isEditable": true,
-          |  "isAnAgent": false,
-          |  "isAnIndividual": true,
-          |  "addressDetails": {
-          |    "addressLine1": "100 SomeStreet",
-          |    "addressLine2": "Wokingham",
-          |    "addressLine3": "Surrey",
-          |    "addressLine4": "London",
-          |    "postalCode": "DH14EJ",
-          |    "countryCode": "GB"
-          |  },
-          |  "contactDetails": {
-          |    "regimeName": "AWRS",
-          |    "phoneNumber": "01332752856",
-          |    "mobileNumber": "07782565326",
-          |    "faxNumber": "01332754256",
-          |    "emailAddress": "stephen@manncorpone.co.uk"
-          |  }
-          |}
-        """.stripMargin
-
-      val successResponse: JsValue = Json.parse(
-        s"""{"processingDate":"2015-12-17T09:30:47Z","etmpFormBundleNumber":"123456789012345","awrsRegistrationNumber": "XAAW00000123456"}"""
-      )
-
-      FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
-
-      val statusresp = Json.obj(
-        "processingDate" -> "20/01/2010",
-        "formBundleStatus" -> Pending.name,
-        "groupBusinessPartner" -> false
-      )
-
-      stubbedGet(s"""$regimeURI""", OK, jsResultString)
-      stubbedPost(s"""$baseURI$subscriptionURI$safeId""", OK, successResponse.toString)
-      stubbedGet(s"""$baseURI${subscriptionURI}XAAW00000123456/status""", OK, statusresp.toString())
-      stubbedPost(s"/auth/authorise", OK,
-        """
-          |{
-          | "affinityGroup": "Individual"
-          |}
-        """.stripMargin)
-      stubbedPut(s"/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey", NO_CONTENT)
-
-      val controllerUrl = routes.EtmpCheckController.checkEtmp().url
-
-      val resp: WSResponse = await(client(controllerUrl).post(jsonPostData))
-      resp.status mustBe 200
-    }
-
-  }
-
 }

--- a/it/uk/gov/hmrc/helpers/controllers/SubscriptionControllerSpec.scala
+++ b/it/uk/gov/hmrc/helpers/controllers/SubscriptionControllerSpec.scala
@@ -16,610 +16,145 @@
 
 package uk.gov.hmrc.helpers.controllers
 
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, stubFor, urlMatching}
-import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import akka.util.Timeout
+import models.Approved
 import org.scalatest.MustMatchers
 import play.api.http.Status._
-import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSResponse
+import uk.gov.hmrc.helpers.utils.{IntegrationData, Stubs}
 import uk.gov.hmrc.helpers.{AuthHelpers, IntegrationSpec}
 import utils.{AWRSFeatureSwitches, FeatureSwitch}
 
-class SubscriptionControllerSpec extends IntegrationSpec with AuthHelpers with MustMatchers {
+import scala.concurrent.duration.FiniteDuration
 
-  val baseURI = "/alcohol-wholesaler-register"
-  val subscriptionURI = "/subscription/"
-  val regimeURI = "/registration/details"
-  val safeId: String = "XE0001234567890"
-  val AWRS_SERVICE_NAME = "HMRC-AWRS-ORG"
-  val enrolmentKey = s"$AWRS_SERVICE_NAME~AWRSRefNumber~XAAW00000123456"
+class SubscriptionControllerSpec extends IntegrationSpec with AuthHelpers with MustMatchers with IntegrationData with Stubs {
+
+  val secondsToWait: Int = 20
 
   val controllerUrl = "/awrs/send-data"
 
-  val jsonOrgPostData = Json.parse("""{
-                                    |  "subscriptionTypeFrontEnd": {
-                                    |    "legalEntity": {
-                                    |      "legalEntity": "LTD"
-                                    |    },
-                                    |    "businessPartnerName": "BusinessPartner",
-                                    |    "groupDeclaration": {
-                                    |      "groupRepConfirmation": true
-                                    |    },
-                                    |    "businessCustomerDetails": {
-                                    |      "businessName": "Trading Trade",
-                                    |      "businessType": "Corporate Body",
-                                    |      "businessAddress": {
-                                    |        "line_1": "1 Example Street",
-                                    |        "line_2": "Exampe View",
-                                    |        "line_3": "Exampe Town",
-                                    |        "line_4": "Exampeshire",
-                                    |        "postcode": "AA1 1AA",
-                                    |        "country": "GB"
-                                    |      },
-                                    |      "sapNumber": "1234567890",
-                                    |      "safeId": "XE0001234567890",
-                                    |      "isAGroup": false,
-                                    |      "agentReferenceNumber": "JARN1234567"
-                                    |    },
-                                    |    "businessDetails": {
-                                    |      "doYouHaveTradingName": "Yes",
-                                    |      "tradingName": "Trading name",
-                                    |      "newAWBusiness": {
-                                    |        "newAWBusiness": "No"
-                                    |      }
-                                    |    },
-                                    |    "businessRegistrationDetails": {
-                                    |      "legalEntity": "LTD",
-                                    |      "isBusinessIncorporated": "Yes",
-                                    |      "companyRegDetails": {
-                                    |        "companyRegistrationNumber": "55555555",
-                                    |        "dateOfIncorporation": "01/01/2015"
-                                    |      },
-                                    |      "doYouHaveVRN": "Yes",
-                                    |      "vrn": "000000000",
-                                    |      "doYouHaveUTR": "Yes",
-                                    |      "utr": "$utr"
-                                    |    },
-                                    |    "placeOfBusiness": {
-                                    |      "mainPlaceOfBusiness": "Yes",
-                                    |      "placeOfBusinessLast3Years": "Yes",
-                                    |      "operatingDuration": "over 10 years",
-                                    |      "modelVersion" : "1.0"
-                                    |    },
-                                    |    "businessContacts": {
-                                    |      "contactAddressSame": "Yes",
-                                    |      "contactFirstName": "first name",
-                                    |      "contactLastName": "last name",
-                                    |      "email": "Email@email.com",
-                                    |      "telephone": "07000111222",
-                                    |      "modelVersion" : "1.1"
-                                    |    },
-                                    |    "additionalPremises": {
-                                    |      "premises": [
-                                    |        {
-                                    |          "additionalPremises": "Yes",
-                                    |          "additionalAddress": {
-                                    |            "postcode": "BB1 1BB",
-                                    |            "addressLine1": "150 Example Avenue",
-                                    |            "addressLine2": "Exampletown"
-                                    |          },
-                                    |          "addAnother": "No"
-                                    |        }
-                                    |      ]
-                                    |    },
-                                    |    "businessDirectors": {
-                                    |      "directors": [
-                                    |        {
-                                    |          "directorsAndCompanySecretaries": "Director",
-                                    |          "personOrCompany": "person",
-                                    |          "firstName": "sdfsd",
-                                    |          "lastName": "sdfsdfsd",
-                                    |          "doTheyHaveNationalInsurance": "Yes",
-                                    |          "nino": "$nino",
-                                    |          "otherDirectors": "Yes"
-                                    |        },
-                                    |        {
-                                    |          "directorsAndCompanySecretaries": "Director and Company Secretary",
-                                    |          "personOrCompany": "person",
-                                    |          "firstName": "Example",
-                                    |          "lastName": "Exampleson",
-                                    |          "doTheyHaveNationalInsurance": "Yes",
-                                    |          "nino": "$nino",
-                                    |          "otherDirectors": "No"
-                                    |        }
-                                    |      ],
-                                    |      "modelVersion" : "1.0"
-                                    |    },
-                                    |    "tradingActivity": {
-                                    |      "wholesalerType": [
-                                    |        "06",
-                                    |        "01",
-                                    |        "02",
-                                    |        "03",
-                                    |        "04",
-                                    |        "05"
-                                    |      ],
-                                    |      "typeOfAlcoholOrders": [
-                                    |        "01",
-                                    |        "02",
-                                    |        "03",
-                                    |        "04"
-                                    |      ],
-                                    |      "doesBusinessImportAlcohol": "Yes",
-                                    |      "doYouExportAlcohol": "Yes",
-                                    |      "exportLocation": [
-                                    |        "euDispatches",
-                                    |        "outsideEU"
-                                    |      ]
-                                    |    },
-                                    |    "products": {
-                                    |      "mainCustomers": [
-                                    |        "01",
-                                    |        "02",
-                                    |        "03",
-                                    |        "04",
-                                    |        "05",
-                                    |        "06",
-                                    |        "07",
-                                    |        "08"
-                                    |      ],
-                                    |      "doesBusinessImportAlcohol": "Yes",
-                                    |      "productType": [
-                                    |        "02",
-                                    |        "03",
-                                    |        "05",
-                                    |        "06",
-                                    |        "99"
-                                    |      ],
-                                    |      "otherProductType": "rwerwrwerew"
-                                    |    },
-                                    |    "suppliers": {
-                                    |      "suppliers": [
-                                    |        {
-                                    |          "alcoholSuppliers": "Yes",
-                                    |          "supplierName": "dfgdfgfd",
-                                    |          "vatRegistered": "No",
-                                    |          "supplierAddress": {
-                                    |            "postcode": "BB1 1BB",
-                                    |            "addressLine1": "150 Example Avenue",
-                                    |            "addressLine2": "Example Avenue"
-                                    |          },
-                                    |          "additionalSupplier": "No"
-                                    |        }
-                                    |      ]
-                                    |    },
-                                    |    "applicationDeclaration": {
-                                    |      "declarationName": "AWRS application",
-                                    |      "declarationRole": "AWRS application1"
-                                    |    },
-                                    |    "modelVersion": "1.0"
-                                    |  }
-                                    |}
-                                    |""".stripMargin)
+  "subscribe()" should {
+    "return 200" when {
+      "EMAC feature switch is true" when {
+        "the etmp subscription is successful" when {
+          "the enrolment upsert is successful" when {
+            "the user is an Organisation" in {
 
+              FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
+              stubShowAndRedirectExternalCalls("Organisation")
+              stubAuditPosts
+              stubAwrsSubscriptionResponse(OK, Some(subscriptionSuccessResponse))
+              stubUpsertAwrsEnrolment(NO_CONTENT)
 
-  val jsonIndividualPostData = Json.parse("""{
-                                            |  "subscriptionTypeFrontEnd": {
-                                            |    "legalEntity": {
-                                            |      "legalEntity": "SOP"
-                                            |    },
-                                            |    "businessPartnerName": "BusinessPartner",
-                                            |    "businessCustomerDetails": {
-                                            |      "businessName": "Example Name",
-                                            |      "businessType": "Sole Trader",
-                                            |      "businessAddress": {
-                                            |        "line_1": "1 Example Street",
-                                            |        "line_2": "Exampe View",
-                                            |        "line_3": "Exampe Town",
-                                            |        "line_4": "Exampeshire",
-                                            |        "postcode": "AA1 1AA",
-                                            |        "country": "GB"
-                                            |      },
-                                            |      "sapNumber": "1234567890",
-                                            |      "safeId": "XE0001234567890",
-                                            |      "isAGroup": false,
-                                            |      "agentReferenceNumber": "01234567890",
-                                            |      "firstName": "Example",
-                                            |      "lastName": "Exampleson"
-                                            |    },
-                                            |    "businessDetails": {
-                                            |      "doYouHaveTradingName": "Yes",
-                                            |      "tradingName": "Example Trading",
-                                            |      "newAWBusiness": {
-                                            |        "newAWBusiness": "No"
-                                            |      }
-                                            |    },
-                                            |    "businessRegistrationDetails": {
-                                            |      "legalEntity": "SOP",
-                                            |      "doYouHaveNino": "Yes",
-                                            |      "nino": "$nino",
-                                            |      "doYouHaveVRN": "Yes",
-                                            |      "vrn": "000000000",
-                                            |      "doYouHaveUTR": "Yes",
-                                            |      "utr": "$utr"
-                                            |    },
-                                            |    "placeOfBusiness": {
-                                            |      "mainPlaceOfBusiness": "Yes",
-                                            |      "placeOfBusinessLast3Years": "Yes",
-                                            |      "operatingDuration": "2 to 5 years",
-                                            |      "modelVersion" : "1.0"
-                                            |    },
-                                            |    "businessContacts": {
-                                            |      "contactAddressSame": "Yes",
-                                            |      "contactFirstName": "Example",
-                                            |      "contactLastName": "Exampleson",
-                                            |      "email": "Example@gmail.com",
-                                            |      "confirmEmail": "Example@gmail.com",
-                                            |      "telephone": "01234567891",
-                                            |      "modelVersion" : "1.0"
-                                            |    },
-                                            |    "additionalPremises": {
-                                            |      "premises": [
-                                            |        {
-                                            |          "additionalPremises": "Yes",
-                                            |          "additionalAddress": {
-                                            |            "postcode": "AA1 1AA",
-                                            |            "addressLine1": "82 Example Street",
-                                            |            "addressLine2": "Exampledon"
-                                            |          },
-                                            |          "addAnother": "Yes"
-                                            |        },
-                                            |        {
-                                            |          "additionalPremises": "Yes",
-                                            |          "additionalAddress": {
-                                            |            "postcode": "AA1 1AA",
-                                            |            "addressLine1": "82 Example Street",
-                                            |            "addressLine2": "Exampledon"
-                                            |          },
-                                            |          "addAnother": "No"
-                                            |        }
-                                            |      ]
-                                            |    },
-                                            |    "tradingActivity": {
-                                            |      "wholesalerType": [
-                                            |        "01",
-                                            |        "02",
-                                            |        "03",
-                                            |        "04",
-                                            |        "05",
-                                            |        "99"
-                                            |      ],
-                                            |      "otherWholesaler": "Other wholesaler type",
-                                            |      "typeOfAlcoholOrders": [
-                                            |        "02",
-                                            |        "03",
-                                            |        "99"
-                                            |      ],
-                                            |      "otherTypeOfAlcoholOrders": "Other alcohol order",
-                                            |      "doesBusinessImportAlcohol": "Yes",
-                                            |      "thirdPartyStorage": "Yes",
-                                            |      "doYouExportAlcohol": "Yes",
-                                            |      "exportLocation": [
-                                            |        "euDispatches",
-                                            |        "outsideEU"
-                                            |      ]
-                                            |    },
-                                            |    "products": {
-                                            |      "mainCustomers": [
-                                            |        "02",
-                                            |        "03"
-                                            |      ],
-                                            |      "productType": [
-                                            |        "03",
-                                            |        "99"
-                                            |      ],
-                                            |      "otherProductType": "Other product type"
-                                            |    },
-                                            |    "suppliers": {
-                                            |      "suppliers": [
-                                            |        {
-                                            |          "alcoholSuppliers": "Yes",
-                                            |          "supplierName": "Example Supplier",
-                                            |          "vatRegistered": "No",
-                                            |          "supplierAddress": {
-                                            |            "postcode": "BB1 1BB",
-                                            |            "addressLine1": "3 Example Road",
-                                            |            "addressLine2": "Exampledon"
-                                            |          },
-                                            |          "additionalSupplier": "Yes"
-                                            |        },
-                                            |        {
-                                            |          "alcoholSuppliers": "Yes",
-                                            |          "supplierName": "ExampleName",
-                                            |          "supplierAddress": {
-                                            |            "postcode": "BB1 1BB",
-                                            |            "addressLine1": "3 Example Road",
-                                            |            "addressLine2": "Exampledon"
-                                            |          },
-                                            |          "additionalSupplier": "No"
-                                            |        }
-                                            |      ]
-                                            |    },
-                                            |    "applicationDeclaration": {
-                                            |      "declarationName": "Example Exampleson",
-                                            |      "declarationRole": "Other"
-                                            |    },
-                                            |    "modelVersion": "1.0"
-                                            |  }
-                                            |}
-                                            |""".stripMargin)
+              val resp: WSResponse = await(client(controllerUrl).post(awrsSubscriptionDataOrg))
+              resp.status mustBe 200
+            }
+          }
 
+          "the enrolment upsert is successful" when {
+            "the user is an Individual" in {
 
-  def stubShowAndRedirectExternalCalls(affinityGroup: String): StubMapping = {
-    stubFor(post(urlMatching("/auth/authorise"))
-      .willReturn(
-        aResponse()
-          .withStatus(OK)
-          .withBody(
-            s"""{
-               |  "authorisedEnrolments": [{}],
-               |  "affinityGroup": "$affinityGroup",
-               |  "credentials": {"providerId": "12345-credId", "providerType": "GovernmentGateway"},
-               |  "authProviderId": { "ggCredId": "123" }
-               |}""".stripMargin
-          )
-      )
-    )
-  }
+              FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
+              stubShowAndRedirectExternalCalls("Individual")
+              stubAuditPosts
+              stubAwrsSubscriptionResponse(OK, Some(subscriptionSuccessResponse))
+              stubUpsertAwrsEnrolment(NO_CONTENT)
 
-  "return bad request" when {
-
-    "AWRS feature flag is false" in {
-
-      val successResponse: JsValue = Json.parse(
-        s"""{"processingDate":"2015-12-17T09:30:47Z","etmpFormBundleNumber":"123456789012345","awrsRegistrationNumber": "DummyRef"}"""
-      )
-
-      stubbedPost(s"""$baseURI$subscriptionURI$safeId""", BAD_REQUEST, successResponse.toString)
-      stubbedPut(s"/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey", OK)
-
-      val resp: WSResponse = await(client(controllerUrl).post(jsonOrgPostData))
-      resp.status mustBe 400
-    }
-
-    "AWRS feature flag is true and malformed json response from regime end point" in {
-
-      val jsResultString =
-        """
-          |{"regimeIdentifiers": [
-          |{
-          |  "regimeName": "String",
-          |  "regimeRefNumber": "AWRS"
-          |}
-          |]}
-        """.stripMargin
-
-      val failureResponse: JsValue = Json.parse(
-        s"""{"reason": "Resource not found"}"""
-      )
-
-      FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
-
-      stubbedGet(s"""$regimeURI""", OK, jsResultString)
-      stubbedPost(s"""$baseURI$subscriptionURI$safeId""", BAD_REQUEST, failureResponse.toString)
-      stubbedPut(s"/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey", OK)
-
-      val resp: WSResponse = await(client(controllerUrl).post(jsonOrgPostData))
-      resp.status mustBe 400
-    }
-
-    "AWRS feature flag is true and Organisation data does not match" in {
-
-      val jsResultString =
-        """
-          |{
-          |  "sapNumber": "1234567890",
-          |  "safeId": "XE0001234567890",
-          |  "agentReferenceNumber": "AARN1234567",
-          |  "regimeIdentifiers": [
-          |    {
-          |      "regimeName": "AWRS",
-          |      "regimeRefNumber": "XAAW00000123456"
-          |    }
-          |  ],
-          |  "nonUKIdentification": {
-          |    "idNumber": "123456",
-          |    "issuingInstitution": "France Institution",
-          |    "issuingCountryCode": "FR"
-          |  },
-          |  "isEditable": true,
-          |  "isAnAgent": false,
-          |  "isAnIndividual": false,
-          |  "organisation": {
-          |    "organisationName": "ACME Trading",
-          |    "isAGroup": false,
-          |    "organisationType": "Corporate body"
-          |  },
-          |  "addressDetails": {
-          |    "addressLine1": "100 SomeStreet",
-          |    "addressLine2": "Wokingham",
-          |    "addressLine3": "Surrey",
-          |    "addressLine4": "London",
-          |    "postalCode": "DH14EJ",
-          |    "countryCode": "GB"
-          |  },
-          |  "contactDetails": {
-          |    "regimeName": "AWRS",
-          |    "phoneNumber": "01332752856",
-          |    "mobileNumber": "07782565326",
-          |    "faxNumber": "01332754256",
-          |    "emailAddress": "stephen@manncorpone.co.uk"
-          |  }
-          |}
-        """.stripMargin
-
-      val failureResponse: JsValue = Json.parse(
-        s"""{"reason": "Resource not found"}"""
-      )
-
-      FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
-      stubShowAndRedirectExternalCalls("Organisation")
-
-      stubbedGet(s"""$regimeURI""", OK, jsResultString)
-      stubbedPost(s"""$baseURI$subscriptionURI$safeId""", BAD_REQUEST, failureResponse.toString)
-      stubbedPut(s"/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey", NO_CONTENT)
-
-      val resp: WSResponse = await(client(controllerUrl).post(jsonOrgPostData))
-      resp.status mustBe 400
-    }
-
-    "AWRS feature flag is true and Individual data does not match" in {
-
-      val jsResultString =
-        """
-          |{
-          |  "sapNumber": "1234567890",
-          |  "safeId": "XE0001234567890",
-          |  "regimeIdentifiers": [
-          |    {
-          |      "regimeName": "AWRS",
-          |      "regimeRefNumber": "XAAW00000123456"
-          |    }
-          |  ],
-          |  "isEditable": true,
-          |  "isAnAgent": false,
-          |  "isAnIndividual": true,
-          |  "individual": {
-          |        "firstName": "first",
-          |        "lastName": "last",
-          |        "dateOfBirth": "1980-12-25"
-          |        },
-          |  "addressDetails": {
-          |    "addressLine1": "100 SomeStreet",
-          |    "addressLine2": "Wokingham",
-          |    "addressLine3": "Surrey",
-          |    "addressLine4": "London",
-          |    "postalCode": "DH14EJ",
-          |    "countryCode": "GB"
-          |  },
-          |  "contactDetails": {}
-          |}
-        """.stripMargin
-
-      val failureResponse: JsValue = Json.parse(
-        s"""{"reason": "Resource not found"}"""
-      )
-
-      FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
-      stubShowAndRedirectExternalCalls("Individual")
-
-      stubbedGet(s"""$regimeURI""", OK, jsResultString)
-      stubbedPost(s"""$baseURI$subscriptionURI$safeId""", BAD_REQUEST, failureResponse.toString)
-      stubbedPut(s"/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey", NO_CONTENT)
-
-      val resp: WSResponse = await(client(controllerUrl).post(jsonIndividualPostData))
-      resp.status mustBe 400
-    }
-
-
-    "return 202" when {
-      "Awrs Feature flag is true and organisation details match" in {
-
-        val jsResultString =
-          """
-            |{
-            |  "sapNumber": "1234567890",
-            |  "safeId": "XE0001234567890",
-            |  "agentReferenceNumber": "JARN1234567",
-            |  "regimeIdentifiers": [
-            |    {
-            |      "regimeName": "AWRS",
-            |      "regimeRefNumber": "XAAW00000123456"
-            |    }
-            |  ],
-            |  "nonUKIdentification": {
-            |    "idNumber": "123456",
-            |    "issuingInstitution": "France Institution",
-            |    "issuingCountryCode": "FR"
-            |  },
-            |  "isEditable": true,
-            |  "isAnAgent": false,
-            |  "isAnIndividual": false,
-            |  "organisation": {
-            |    "organisationName": "Trading Trade",
-            |    "isAGroup": false,
-            |    "organisationType": "Corporate body"
-            |  },
-            |  "addressDetails": {
-            |    "addressLine1": "100 SomeStreet",
-            |    "addressLine2": "Wokingham",
-            |    "addressLine3": "Surrey",
-            |    "addressLine4": "London",
-            |    "postalCode": "DH14EJ",
-            |    "countryCode": "GB"
-            |  },
-            |  "contactDetails": {
-            |    "regimeName": "AWRS",
-            |    "phoneNumber": "01332752856",
-            |    "mobileNumber": "07782565326",
-            |    "faxNumber": "01332754256",
-            |    "emailAddress": "stephen@manncorpone.co.uk"
-            |  }
-            |}
-          """.stripMargin
-
-        val failureResponse: JsValue = Json.parse(
-          s"""{"reason": "Resource not found"}"""
-        )
-
-        FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
-        stubShowAndRedirectExternalCalls("Organisation")
-
-        stubbedGet(s"""$regimeURI""", OK, jsResultString)
-        stubbedPost(s"""$baseURI$subscriptionURI$safeId""", BAD_REQUEST, failureResponse.toString)
-        stubbedPut(s"/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey", NO_CONTENT)
-
-        val resp: WSResponse = await(client(controllerUrl).post(jsonOrgPostData))
-        resp.status mustBe 202
+              val resp: WSResponse = await(client(controllerUrl).post(awrsSubscriptionDataInd))
+              resp.status mustBe 200
+            }
+          }
+        }
       }
     }
 
-    "AWRS feature flag is true for an individual" in {
+    "return 202 for a successful self heal" when {
+      "EMAC feature switch is true" when {
+        "the awrs subscription failed because it already exists" when {
+          "Organisation details match business partner" in {
 
-      val jsResultString =
-        """
-          |{
-          |  "sapNumber": "1234567890",
-          |  "safeId": "XE0001234567890",
-          |  "regimeIdentifiers": [
-          |    {
-          |      "regimeName": "AWRS",
-          |      "regimeRefNumber": "XAAW00000123456"
-          |    }
-          |  ],
-          |  "isEditable": true,
-          |  "isAnAgent": false,
-          |  "isAnIndividual": true,
-          |  "individual": {
-          |        "firstName": "Example",
-          |        "lastName": "Exampleson",
-          |        "dateOfBirth": "1980-12-25"
-          |        },
-          |  "addressDetails": {
-          |    "addressLine1": "100 SomeStreet",
-          |    "addressLine2": "Wokingham",
-          |    "addressLine3": "Surrey",
-          |    "addressLine4": "London",
-          |    "postalCode": "AA1 1AA",
-          |    "countryCode": "GB"
-          |  },
-          |  "contactDetails": {}
-          |}
-        """.stripMargin
+            FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
+            stubShowAndRedirectExternalCalls("Organisation")
+            stubAuditPosts
+            stubAwrsSubscriptionResponse(BAD_REQUEST)
+            stubEtmpRegistrationResponse(OK, etmpRegistrationResultOrg)
+            stubGetSubscriptionStatus(OK, Some(Approved.name))
+            stubUpsertAwrsEnrolment(NO_CONTENT)
 
-      val successResponse: JsValue = Json.parse(
-        s"""{"processingDate":"2015-12-17T09:30:47Z","etmpFormBundleNumber":"123456789012345","awrsRegistrationNumber": "XAAW00000123456"}"""
-      )
+            val resp: WSResponse = await(client(controllerUrl).post(awrsSubscriptionDataOrg))
+            resp.status mustBe 202
+          }
 
-      FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
-      stubShowAndRedirectExternalCalls("Individual")
+          "Individual details match the business partner" in {
 
-      stubbedGet(s"""$regimeURI""", OK, jsResultString)
-      stubbedPost(s"""$baseURI$subscriptionURI$safeId""", BAD_REQUEST, successResponse.toString)
-      stubbedPut(s"/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey", NO_CONTENT)
+            FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
+            stubShowAndRedirectExternalCalls("Individual")
+            stubAuditPosts
+            stubEtmpRegistrationResponse(OK, etmpRegistrationResultInd)
+            stubGetSubscriptionStatus(OK, Some(Approved.name))
+            stubAwrsSubscriptionResponse(BAD_REQUEST)
+            stubUpsertAwrsEnrolment(NO_CONTENT)
 
-      val resp: WSResponse = await(client(controllerUrl).post(jsonIndividualPostData))
-      resp.status mustBe 202
+            val resp: WSResponse = await(client(controllerUrl).post(awrsSubscriptionDataInd))
+            resp.status mustBe 202
+          }
+        }
+      }
+    }
+
+    "return 400" when {
+
+      "EMAC feature switch is false" when {
+        "the awrs subscription fails" in {
+
+          FeatureSwitch.disable(AWRSFeatureSwitches.regimeCheck())
+          stubAuditPosts
+          stubAwrsSubscriptionResponse(BAD_REQUEST)
+
+          val resp: WSResponse = await(client(controllerUrl).post(awrsSubscriptionDataOrg))
+          resp.status mustBe 400
+        }
+      }
+
+      "EMAC feature switch is true" when {
+        "the awrs subscription failed because it already exists" when {
+          "self heal cannot be attempted because Organisation data does not match business partner" in {
+
+            val modifiedRegistrationResult = etmpRegistrationResultOrg.replace("Trading Trade", "Wrong Org Name")
+
+            FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
+            stubShowAndRedirectExternalCalls("Organisation")
+            stubAuditPosts
+            stubEtmpRegistrationResponse(OK, modifiedRegistrationResult)
+            stubAwrsSubscriptionResponse(BAD_REQUEST)
+            stubGetSubscriptionStatus(OK, Some(Approved.name))
+            stubUpsertAwrsEnrolment(NO_CONTENT)
+
+            val resp: WSResponse = await(client(controllerUrl).post(awrsSubscriptionDataOrg))
+            resp.status mustBe 400
+          }
+
+
+          "self heal cannot be attempted because Individual data does not match business partner" in {
+
+            val modifiedRegistrationResult = etmpRegistrationResultInd.replace("firstName", "wrong first name")
+
+            FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
+            stubShowAndRedirectExternalCalls("Individual")
+            stubAuditPosts
+            stubEtmpRegistrationResponse(OK, modifiedRegistrationResult)
+            stubAwrsSubscriptionResponse(BAD_REQUEST)
+            stubGetSubscriptionStatus(OK, Some(Approved.name))
+            stubUpsertAwrsEnrolment(NO_CONTENT)
+
+            val resp = await(
+              client(controllerUrl).post(awrsSubscriptionDataInd))(Timeout(FiniteDuration(secondsToWait, "seconds")
+            ))
+
+            resp.status mustBe 400
+          }
+        }
+      }
     }
   }
 }

--- a/it/uk/gov/hmrc/helpers/http/StubbedBasicHttpCalls.scala
+++ b/it/uk/gov/hmrc/helpers/http/StubbedBasicHttpCalls.scala
@@ -6,28 +6,8 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping
 
 trait StubbedBasicHttpCalls {
 
-  def stubbedHead(url: String, statusCode: Int): StubMapping = {
-    stubFor(head(urlMatching(url))
-      .willReturn(
-        aResponse()
-          .withStatus(statusCode)
-      )
-    )
-  }
-
   def stubbedGet(url: String, statusCode: Int, responseBody: String): StubMapping = {
     stubFor(get(urlPathMatching(url))
-      .willReturn(
-        aResponse()
-          .withStatus(statusCode)
-          .withBody(responseBody)
-      )
-    )
-  }
-
-  def  stubbedGetQueryParams(url: String, statusCode: Int, responseBody: String): StubMapping = {
-    stubFor(get(urlPathEqualTo(url))
-      .withQueryParam("encoding-type", equalTo("url"))
       .willReturn(
         aResponse()
           .withStatus(statusCode)
@@ -48,25 +28,6 @@ trait StubbedBasicHttpCalls {
 
   def stubbedPut(url: String, statusCode: Int): StubMapping = {
     stubFor(put(urlMatching(url))
-      .willReturn(
-        aResponse()
-          .withStatus(statusCode)
-      )
-    )
-  }
-
-  def stubbedPatch(url: String, statusCode: Int, responseBody: String = ""): StubMapping = {
-    stubFor(patch(urlMatching(url))
-      .willReturn(
-        aResponse()
-          .withStatus(statusCode)
-          .withBody(responseBody)
-      )
-    )
-  }
-
-  def stubbedDelete(url: String, statusCode: Int): StubMapping = {
-    stubFor(delete(urlMatching(url))
       .willReturn(
         aResponse()
           .withStatus(statusCode)

--- a/it/uk/gov/hmrc/helpers/utils/IntegrationData.scala
+++ b/it/uk/gov/hmrc/helpers/utils/IntegrationData.scala
@@ -1,0 +1,457 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helpers.utils
+
+import play.api.libs.json.{JsValue, Json}
+
+trait IntegrationData {
+
+  val safeId: String = "XE0001234567890"
+  val baseURI = "/alcohol-wholesaler-register"
+  val subscriptionURI = "/subscription/"
+  val statusURI = "/status"
+  val enrolmentRef = "XAAW00000123456"
+  val enrolmentKey = s"HMRC-AWRS-ORG~AWRSRefNumber~$enrolmentRef"
+  val regimeURI = "/registration/details"
+
+  val etmpRegistrationResultInd: String =
+    """
+      |{
+      |  "sapNumber": "1234567890",
+      |  "safeId": "XE0001234567890",
+      |  "regimeIdentifiers": [
+      |    {
+      |      "regimeName": "AWRS",
+      |      "regimeRefNumber": "XAAW00000123456"
+      |    }
+      |  ],
+      |  "isEditable": true,
+      |  "isAnAgent": false,
+      |  "isAnIndividual": true,
+      |  "individual": {
+      |        "firstName": "Example",
+      |        "lastName": "Exampleson",
+      |        "dateOfBirth": "1980-12-25"
+      |        },
+      |  "addressDetails": {
+      |    "addressLine1": "100 SomeStreet",
+      |    "addressLine2": "Wokingham",
+      |    "addressLine3": "Surrey",
+      |    "addressLine4": "London",
+      |    "postalCode": "AA1 1AA",
+      |    "countryCode": "GB"
+      |  },
+      |  "contactDetails": {}
+      |}
+    """.stripMargin
+
+  val etmpRegistrationResultOrg: String =
+    """
+      |{
+      |  "sapNumber": "1234567890",
+      |  "safeId": "XE0001234567890",
+      |  "regimeIdentifiers": [
+      |    {
+      |      "regimeName": "AWRS",
+      |      "regimeRefNumber": "XAAW00000123456"
+      |    }
+      |  ],
+      |  "isEditable": true,
+      |  "isAnAgent": false,
+      |  "isAnIndividual": false,
+      |  "organisation": {
+      |        "organisationName": "Trading Trade"
+      |        },
+      |  "addressDetails": {
+      |    "addressLine1": "100 SomeStreet",
+      |    "addressLine2": "Wokingham",
+      |    "addressLine3": "Surrey",
+      |    "addressLine4": "London",
+      |    "postalCode": "AA1 1AA",
+      |    "countryCode": "GB"
+      |  },
+      |  "contactDetails": {
+      |    "regimeName": "AWRS",
+      |    "phoneNumber": "01332752856",
+      |    "mobileNumber": "07782565326",
+      |    "faxNumber": "01332754256",
+      |    "emailAddress": "stephen@manncorpone.co.uk"
+      |  }
+      |}
+    """.stripMargin
+
+  val awrsSubscriptionDataOrg: JsValue = Json.parse(
+    """{
+      |  "subscriptionTypeFrontEnd": {
+      |    "legalEntity": {
+      |      "legalEntity": "LTD"
+      |    },
+      |    "businessPartnerName": "BusinessPartner",
+      |    "groupDeclaration": {
+      |      "groupRepConfirmation": true
+      |    },
+      |    "businessCustomerDetails": {
+      |      "businessName": "Trading Trade",
+      |      "businessType": "Corporate Body",
+      |      "businessAddress": {
+      |        "line_1": "1 Example Street",
+      |        "line_2": "Exampe View",
+      |        "line_3": "Exampe Town",
+      |        "line_4": "Exampeshire",
+      |        "postcode": "AA1 1AA",
+      |        "country": "GB"
+      |      },
+      |      "sapNumber": "1234567890",
+      |      "safeId": "XE0001234567890",
+      |      "isAGroup": false
+      |    },
+      |    "businessDetails": {
+      |      "doYouHaveTradingName": "Yes",
+      |      "tradingName": "Trading name",
+      |      "newAWBusiness": {
+      |        "newAWBusiness": "No"
+      |      }
+      |    },
+      |    "businessRegistrationDetails": {
+      |      "legalEntity": "LTD",
+      |      "isBusinessIncorporated": "Yes",
+      |      "companyRegDetails": {
+      |        "companyRegistrationNumber": "55555555",
+      |        "dateOfIncorporation": "01/01/2015"
+      |      },
+      |      "doYouHaveVRN": "Yes",
+      |      "vrn": "000000000",
+      |      "doYouHaveUTR": "Yes",
+      |      "utr": "$utr"
+      |    },
+      |    "placeOfBusiness": {
+      |      "mainPlaceOfBusiness": "Yes",
+      |      "placeOfBusinessLast3Years": "Yes",
+      |      "operatingDuration": "over 10 years",
+      |      "modelVersion" : "1.0"
+      |    },
+      |    "businessContacts": {
+      |      "contactAddressSame": "Yes",
+      |      "contactFirstName": "first name",
+      |      "contactLastName": "last name",
+      |      "email": "Email@email.com",
+      |      "telephone": "07000111222",
+      |      "modelVersion" : "1.1"
+      |    },
+      |    "additionalPremises": {
+      |      "premises": [
+      |        {
+      |          "additionalPremises": "Yes",
+      |          "additionalAddress": {
+      |            "postcode": "BB1 1BB",
+      |            "addressLine1": "150 Example Avenue",
+      |            "addressLine2": "Exampletown"
+      |          },
+      |          "addAnother": "No"
+      |        }
+      |      ]
+      |    },
+      |    "businessDirectors": {
+      |      "directors": [
+      |        {
+      |          "directorsAndCompanySecretaries": "Director",
+      |          "personOrCompany": "person",
+      |          "firstName": "sdfsd",
+      |          "lastName": "sdfsdfsd",
+      |          "doTheyHaveNationalInsurance": "Yes",
+      |          "nino": "$nino",
+      |          "otherDirectors": "Yes"
+      |        },
+      |        {
+      |          "directorsAndCompanySecretaries": "Director and Company Secretary",
+      |          "personOrCompany": "person",
+      |          "firstName": "Example",
+      |          "lastName": "Exampleson",
+      |          "doTheyHaveNationalInsurance": "Yes",
+      |          "nino": "$nino",
+      |          "otherDirectors": "No"
+      |        }
+      |      ],
+      |      "modelVersion" : "1.0"
+      |    },
+      |    "tradingActivity": {
+      |      "wholesalerType": [
+      |        "06",
+      |        "01",
+      |        "02",
+      |        "03",
+      |        "04",
+      |        "05"
+      |      ],
+      |      "typeOfAlcoholOrders": [
+      |        "01",
+      |        "02",
+      |        "03",
+      |        "04"
+      |      ],
+      |      "doesBusinessImportAlcohol": "Yes",
+      |      "doYouExportAlcohol": "Yes",
+      |      "exportLocation": [
+      |        "euDispatches",
+      |        "outsideEU"
+      |      ]
+      |    },
+      |    "products": {
+      |      "mainCustomers": [
+      |        "01",
+      |        "02",
+      |        "03",
+      |        "04",
+      |        "05",
+      |        "06",
+      |        "07",
+      |        "08"
+      |      ],
+      |      "doesBusinessImportAlcohol": "Yes",
+      |      "productType": [
+      |        "02",
+      |        "03",
+      |        "05",
+      |        "06",
+      |        "99"
+      |      ],
+      |      "otherProductType": "rwerwrwerew"
+      |    },
+      |    "suppliers": {
+      |      "suppliers": [
+      |        {
+      |          "alcoholSuppliers": "Yes",
+      |          "supplierName": "dfgdfgfd",
+      |          "vatRegistered": "No",
+      |          "supplierAddress": {
+      |            "postcode": "BB1 1BB",
+      |            "addressLine1": "150 Example Avenue",
+      |            "addressLine2": "Example Avenue"
+      |          },
+      |          "additionalSupplier": "No"
+      |        }
+      |      ]
+      |    },
+      |    "applicationDeclaration": {
+      |      "declarationName": "AWRS application",
+      |      "declarationRole": "AWRS application1"
+      |    },
+      |    "modelVersion": "1.0"
+      |  }
+      |}
+      |""".stripMargin)
+
+
+  val awrsSubscriptionDataInd: JsValue = Json.parse(
+    """{
+      |  "subscriptionTypeFrontEnd": {
+      |    "legalEntity": {
+      |      "legalEntity": "SOP"
+      |    },
+      |    "businessPartnerName": "BusinessPartner",
+      |    "businessCustomerDetails": {
+      |      "businessName": "Example Name",
+      |      "businessType": "Sole Trader",
+      |      "businessAddress": {
+      |        "line_1": "1 Example Street",
+      |        "line_2": "Exampe View",
+      |        "line_3": "Exampe Town",
+      |        "line_4": "Exampeshire",
+      |        "postcode": "AA1 1AA",
+      |        "country": "GB"
+      |      },
+      |      "sapNumber": "1234567890",
+      |      "safeId": "XE0001234567890",
+      |      "isAGroup": false,
+      |      "agentReferenceNumber": "01234567890",
+      |      "firstName": "Example",
+      |      "lastName": "Exampleson"
+      |    },
+      |    "businessDetails": {
+      |      "doYouHaveTradingName": "Yes",
+      |      "tradingName": "Example Trading",
+      |      "newAWBusiness": {
+      |        "newAWBusiness": "No"
+      |      }
+      |    },
+      |    "businessRegistrationDetails": {
+      |      "legalEntity": "SOP",
+      |      "doYouHaveNino": "Yes",
+      |      "nino": "$nino",
+      |      "doYouHaveVRN": "Yes",
+      |      "vrn": "000000000",
+      |      "doYouHaveUTR": "Yes",
+      |      "utr": "$utr"
+      |    },
+      |    "placeOfBusiness": {
+      |      "mainPlaceOfBusiness": "Yes",
+      |      "placeOfBusinessLast3Years": "Yes",
+      |      "operatingDuration": "2 to 5 years",
+      |      "modelVersion" : "1.0"
+      |    },
+      |    "businessContacts": {
+      |      "contactAddressSame": "Yes",
+      |      "contactFirstName": "Example",
+      |      "contactLastName": "Exampleson",
+      |      "email": "Example@gmail.com",
+      |      "confirmEmail": "Example@gmail.com",
+      |      "telephone": "01234567891",
+      |      "modelVersion" : "1.0"
+      |    },
+      |    "additionalPremises": {
+      |      "premises": [
+      |        {
+      |          "additionalPremises": "Yes",
+      |          "additionalAddress": {
+      |            "postcode": "AA1 1AA",
+      |            "addressLine1": "82 Example Street",
+      |            "addressLine2": "Exampledon"
+      |          },
+      |          "addAnother": "Yes"
+      |        },
+      |        {
+      |          "additionalPremises": "Yes",
+      |          "additionalAddress": {
+      |            "postcode": "AA1 1AA",
+      |            "addressLine1": "82 Example Street",
+      |            "addressLine2": "Exampledon"
+      |          },
+      |          "addAnother": "No"
+      |        }
+      |      ]
+      |    },
+      |    "tradingActivity": {
+      |      "wholesalerType": [
+      |        "01",
+      |        "02",
+      |        "03",
+      |        "04",
+      |        "05",
+      |        "99"
+      |      ],
+      |      "otherWholesaler": "Other wholesaler type",
+      |      "typeOfAlcoholOrders": [
+      |        "02",
+      |        "03",
+      |        "99"
+      |      ],
+      |      "otherTypeOfAlcoholOrders": "Other alcohol order",
+      |      "doesBusinessImportAlcohol": "Yes",
+      |      "thirdPartyStorage": "Yes",
+      |      "doYouExportAlcohol": "Yes",
+      |      "exportLocation": [
+      |        "euDispatches",
+      |        "outsideEU"
+      |      ]
+      |    },
+      |    "products": {
+      |      "mainCustomers": [
+      |        "02",
+      |        "03"
+      |      ],
+      |      "productType": [
+      |        "03",
+      |        "99"
+      |      ],
+      |      "otherProductType": "Other product type"
+      |    },
+      |    "suppliers": {
+      |      "suppliers": [
+      |        {
+      |          "alcoholSuppliers": "Yes",
+      |          "supplierName": "Example Supplier",
+      |          "vatRegistered": "No",
+      |          "supplierAddress": {
+      |            "postcode": "BB1 1BB",
+      |            "addressLine1": "3 Example Road",
+      |            "addressLine2": "Exampledon"
+      |          },
+      |          "additionalSupplier": "Yes"
+      |        },
+      |        {
+      |          "alcoholSuppliers": "Yes",
+      |          "supplierName": "ExampleName",
+      |          "supplierAddress": {
+      |            "postcode": "BB1 1BB",
+      |            "addressLine1": "3 Example Road",
+      |            "addressLine2": "Exampledon"
+      |          },
+      |          "additionalSupplier": "No"
+      |        }
+      |      ]
+      |    },
+      |    "applicationDeclaration": {
+      |      "declarationName": "Example Exampleson",
+      |      "declarationRole": "Other"
+      |    },
+      |    "modelVersion": "1.0"
+      |  }
+      |}
+      |""".stripMargin)
+
+  val subscriptionSuccessResponse: String =
+    """{
+      |"processingDate":"2015-12-17T09:30:47Z",
+      |"etmpFormBundleNumber":"123456789012345",
+      |"awrsRegistrationNumber": "XAAW00000123456"
+      |}""".stripMargin
+
+  val checkEtmpPostDataOrg: JsValue = Json.parse(
+    """{
+      |  "businessCustomerDetails": {
+      |    "businessName": "Trading Trade",
+      |    "businessType": "Corporate Body",
+      |    "businessAddress": {
+      |      "line_1": "1 Example Street",
+      |      "line_2": "Exampe View",
+      |      "postcode": "AA1 1AA",
+      |      "country": "GB"
+      |    },
+      |    "sapNumber": "1234567890",
+      |    "safeId": "XE0001234567890",
+      |    "isAGroup": false,
+      |    "utr": "utr"
+      |  },
+      |  "legalEntity": "LTD"
+      |}
+      |""".stripMargin
+  )
+
+  val checkEtmpPostDataInd: JsValue = Json.parse(
+    """{
+      |  "businessCustomerDetails": {
+      |    "businessName": "",
+      |    "firstName": "Example",
+      |    "lastName": "Exampleson",
+      |    "businessType": "SOP",
+      |    "businessAddress": {
+      |      "line_1": "1 Example Street",
+      |      "line_2": "Exampe View",
+      |      "postcode": "AA1 1AA",
+      |      "country": "GB"
+      |    },
+      |    "sapNumber": "1234567890",
+      |    "safeId": "XE0001234567890",
+      |    "isAGroup": false,
+      |    "utr": "utr"
+      |  },
+      |  "legalEntity": "SOP"
+      |}
+      |""".stripMargin
+  )
+
+}

--- a/it/uk/gov/hmrc/helpers/utils/Stubs.scala
+++ b/it/uk/gov/hmrc/helpers/utils/Stubs.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helpers.utils
+
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, stubFor, urlMatching}
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.Status.OK
+import play.api.libs.json.Json
+import uk.gov.hmrc.helpers.IntegrationSpec
+
+trait Stubs extends IntegrationSpec with IntegrationData {
+
+  def stubShowAndRedirectExternalCalls(affinityGroup: String): StubMapping = {
+    stubFor(post(urlMatching("/auth/authorise"))
+      .willReturn(
+        aResponse()
+          .withStatus(OK)
+          .withBody(
+            s"""{
+               |  "authorisedEnrolments": [{}],
+               |  "affinityGroup": "$affinityGroup",
+               |  "credentials": {"providerId": "12345-credId", "providerType": "GovernmentGateway"},
+               |  "authProviderId": { "ggCredId": "123" }
+               |}""".stripMargin
+          )
+      )
+    )
+  }
+
+  def stubEtmpRegistrationResponse(status: Int, body: String): StubMapping = {
+    stubbedGet(regimeURI, status, body)
+  }
+
+  def stubAwrsSubscriptionResponse(status: Int, body: Option[String] = None): StubMapping = {
+    stubbedPost(s"$baseURI$subscriptionURI$safeId", status, body.getOrElse(""))
+  }
+
+  def stubGetSubscriptionStatus(status: Int, awrsStatus: Option[String] = None): StubMapping = {
+    val responseBody: String = awrsStatus.fold(""){awrsStat =>
+      Json.obj(
+      "processingDate" -> "20/01/2010",
+      "formBundleStatus" -> awrsStat,
+      "groupBusinessPartner" -> false
+      ).toString
+    }
+    stubbedGet(s"""$baseURI$subscriptionURI$enrolmentRef$statusURI""", status, responseBody)
+  }
+
+  def stubUpsertAwrsEnrolment(status: Int): StubMapping = {
+    stubbedPut(s"/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey", status)
+  }
+
+  def stubAuditPosts: StubMapping = {
+    stubbedPost("/write/audit", OK, "")
+    stubbedPost("/write/audit/merged", OK, "")
+  }
+
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -18,18 +18,18 @@ object AppDependencies {
   import play.sbt.PlayImport._
   import play.core.PlayVersion
 
-  private val domainVersion = "5.9.0-play-27"
+  private val domainVersion = "5.10.0-play-27"
   private val scalaTestplusPlayVersion = "4.0.3"
   private val pegdownVersion = "1.6.0"
-  private val json4sJacksonVersion = "3.6.9"
+  private val json4sJacksonVersion = "3.6.10"
   private val jsonSchemaValidatorVersion = "2.2.6"
-  private val json4sNativeVersion = "3.6.9"
+  private val json4sNativeVersion = "3.6.10"
   private val mockitoCoreVersion = "3.3.3"
   private val webbitServerVersion = "0.4.15"
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-backend-play-27" % "2.24.0",
+    "uk.gov.hmrc" %% "bootstrap-backend-play-27" % "2.25.0",
     "uk.gov.hmrc" %% "domain" % domainVersion,
     "org.json4s" %% "json4s-jackson" % json4sJacksonVersion,
     "com.github.fge" % "json-schema-validator" % jsonSchemaValidatorVersion,
@@ -48,7 +48,7 @@ object AppDependencies {
         "org.pegdown" % "pegdown" % pegdownVersion % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % scalaTestplusPlayVersion % scope,
-        "org.scalatest" %% "scalatest" % "3.0.8" % scope,
+        "org.scalatest" %% "scalatest" % "3.0.9" % scope,
         "org.scalacheck" %% "scalacheck" % "1.14.3" % scope,
         "org.jsoup" % "jsoup" % "1.11.3" % scope,
         "org.json4s" %% "json4s-jackson" % json4sJacksonVersion,
@@ -76,4 +76,3 @@ object AppDependencies {
 
   def apply(): Seq[ModuleID] = compile ++ Test() ++ IntegrationTest()
 }
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.co
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.10.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
@@ -17,5 +17,3 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-settings" % "4.5.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.5.0")

--- a/test/services/EtmpRegimeServiceTest.scala
+++ b/test/services/EtmpRegimeServiceTest.scala
@@ -174,19 +174,6 @@ class EtmpRegimeServiceTest extends BaseSpec with WordSpecLike with MustMatchers
       await(result) shouldBe None
     }
 
-    "fail to return if the etmp call throws an exception" in {
-      FeatureSwitch.enable(AWRSFeatureSwitches.regimeCheck())
-
-      when(mockEtmpConnector.awrsRegime(ArgumentMatchers.any())(ArgumentMatchers.any()))
-        .thenReturn(Future.failed(new RuntimeException("test")))
-      val businessAddress = BCAddress("1 LS House", "LS Way", Some("LS"), Some("Line 4"), Some("Postcode"), "GB")
-      val businessCustomerDetails = BusinessCustomerDetails("ACME Trading", Some("Corporate Body"), businessAddress, "1234567890",
-        "XE0001234567890", isAGroup = false, Some("XAAW00000123456"), Some("AARN1234567"), None, None)
-      val result = TestEtmpRegimeService.checkETMPApi(businessCustomerDetails, "")
-
-      await(result) shouldBe None
-    }
-
     "fail to return a regimeRefNumber when the feature switch is disabled" in {
       FeatureSwitch.disable(AWRSFeatureSwitches.regimeCheck())
       val businessAddress = BCAddress("1 LS House", "LS Way", Some("LS"), Some("Line 4"), Some("Postcode"), "GB")

--- a/test/services/SubscriptionServiceTest.scala
+++ b/test/services/SubscriptionServiceTest.scala
@@ -64,11 +64,11 @@ class SubscriptionServiceTest extends BaseSpec with WordSpecLike with MustMatche
   }
 
   def subscriptionServicesPart2EMAC(testSubscriptionService: => SubscriptionService): Unit = {
-    "subscribe when we are passed valid json" in {
+    "subscribe when we are passed valid json and the subscription and enrolment creation are successful" in {
       when(mockEtmpConnector.subscribe(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any()))
         .thenReturn(Future.successful(HttpResponse(OK, successResponse, Map.empty[String, Seq[String]])))
       when(mockEnrolmentStoreConnector.upsertEnrolment(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any()))
-        .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, failureResponse, Map.empty[String, Seq[String]])))
+        .thenReturn(Future.successful(HttpResponse(NO_CONTENT, ggEnrolResponse, Map.empty[String, Seq[String]])))
 
       val result = testSubscriptionService.subscribe(inputJson, safeId, Some(testUtr), "SOP", "postcode")
       val response = await(result)
@@ -76,15 +76,14 @@ class SubscriptionServiceTest extends BaseSpec with WordSpecLike with MustMatche
       response.json shouldBe successResponse
     }
 
-    "respond with Ok, when subscription works but enrolment store connector request fails with a Bad request but audit the Bad request" in {
+    "respond with BAD_REQUEST, when subscription works but enrolment store connector request fails with a Bad request but audit the Bad request" in {
       when(mockEtmpConnector.subscribe(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any()))
         .thenReturn(Future.successful(HttpResponse(OK, successResponse, Map.empty[String, Seq[String]])))
       when(mockEnrolmentStoreConnector.upsertEnrolment(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any()))
         .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, failureResponse, Map.empty[String, Seq[String]])))
       val result = testSubscriptionService.subscribe(inputJson, safeId, Some(testUtr), "SOP", "postcode")
       val response = await(result)
-      response.status shouldBe OK
-      response.json shouldBe successResponse
+      response.status shouldBe BAD_REQUEST
     }
   }
 


### PR DESCRIPTION
DL-4363: Show error to user when enrolment call fails

Bug fix

When an enrolment upsert failed before this change, the result was disregarded and the logic used the result of the etmp subscription instead. So if the ETMP subscription was successful but the enrolment upsert failed, the user would be presented with a successful confirmation with a missing AWRS reference. I have updated the logic so that now the result of subscription is based on the outcome of subscription and enrolment. If either of them fail, the user will now see an error screen instead of a successful submission confirmation.

This will tell the user that there was a problem and make them more likely to submit a deskpro using get help with this page so we can help them earlier.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
