### PR TITLE
DL-6372 pad CRNs to 8 digits to pass DES validation

### DIFF
--- a/test/models/EtmpModelHelperSpec.scala
+++ b/test/models/EtmpModelHelperSpec.scala
@@ -854,7 +854,23 @@ class EtmpModelHelperSpec extends PlaySpec with AwrsTestJson with WordSpecLike w
       val awrsModel = Json.parse(updatedJson).as[AWRSFEModel]
       val etmpJson = Json.toJson(awrsModel)(AWRSFEModel.etmpWriter).toString()
 
-      etmpJson should include("\"llpCorporateBody\":{\"incorporationDetails\":{\"isBusinessIncorporated\":true,\"companyRegistrationNumber\":\"7HKJHJH\"")
+      etmpJson should include("\"llpCorporateBody\":{\"incorporationDetails\":{\"isBusinessIncorporated\":true,\"companyRegistrationNumber\":\"07HKJHJH\"")
+    }
+
+    "transform to correct toEtmpCorporateBusinessDetails with company Registration Number padded to 8 digits" in {
+      val deletedJson = deleteFromJson(JsPath \ "subscriptionTypeFrontEnd" \ "businessRegistrationDetails" \ "companyRegDetails" \ "companyRegistrationNumber", api4FrontendLTDString)
+
+      val updatedJson = updateJson(Json.
+        obj("subscriptionTypeFrontEnd" -> Json.
+          obj("businessRegistrationDetails" -> Json.
+            obj("companyRegDetails" -> Json.obj("companyRegistrationNumber" -> "short")
+            ))),
+        deletedJson)
+
+      val awrsModel = Json.parse(updatedJson).as[AWRSFEModel]
+      val etmpJson = Json.toJson(awrsModel)(AWRSFEModel.etmpWriter).toString()
+
+      etmpJson should include("\"llpCorporateBody\":{\"incorporationDetails\":{\"isBusinessIncorporated\":true,\"companyRegistrationNumber\":\"000SHORT\"")
     }
   }
 


### PR DESCRIPTION
# DL-6372  - AWRS: User cannot update director details

**Bug fix** 

All CRNs in Companies House are 8 digits, padded left with 0s. An ongoing live issue is caused by companies passing just the non-zero digits of their CRNs into AWRS but DES requires 8 characters.
This fix removes spaces (these seem to be added by users to pass validation when they think the CRN is shorter than 8?) and prepends the valid CRN digits with 0s to match Companies House.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
